### PR TITLE
feat(terraform): provision remote state backend with S3 and DynamoDB locking

### DIFF
--- a/terraform/backend/README.md
+++ b/terraform/backend/README.md
@@ -1,0 +1,83 @@
+# Remote State Bootstrap
+
+This module provisions the shared backend infrastructure required by all other
+Terraform modules in the Honeynet project.
+
+## Resources
+
+| Resource                                             | Purpose                                                     |
+| ---------------------------------------------------- | ----------------------------------------------------------- |
+| `aws_s3_bucket`                                      | Stores `.tfstate` files for all modules                     |
+| `aws_s3_bucket_versioning`                           | Enables recovery from accidental state corruption           |
+| `aws_s3_bucket_server_side_encryption_configuration` | AES-256 at-rest encryption                                  |
+| `aws_s3_bucket_public_access_block`                  | Prevents any public exposure of state files                 |
+| `aws_s3_bucket_lifecycle_configuration`              | Expires old state versions after 90 days                    |
+| `aws_dynamodb_table`                                 | Prevents concurrent `terraform apply` races (state locking) |
+
+## Usage
+
+This module must be applied **once** using local state before any other modules
+are initialised with the remote backend.
+
+```bash
+cd terraform/backend
+terraform init
+terraform apply
+```
+
+After apply, copy the `backend_config_snippet` output into each module's
+`terraform` block.
+
+## Security notes
+
+- State files may contain sensitive values (IP addresses, credentials). The
+  bucket is fully private with SSE-AES256 enabled.
+- The DynamoDB table uses `PAY_PER_REQUEST` billing — no capacity planning
+  needed, cost is effectively zero at this scale.
+- Point-in-time recovery is enabled on the lock table as a precaution.
+
+```
+
+**PR title:** `feat(terraform): provision remote state backend with S3 and DynamoDB locking`
+
+**PR description:**
+```
+
+## Summary
+
+Sets up the shared remote state infrastructure for the project. Currently all modules use local state, which means state files sit on developer laptops and concurrent applies can silently corrupt each other. This PR fixes that permanently.
+
+## Problem
+
+Local Terraform state is fine for a solo experiment, but the moment two contributors run `terraform apply` at the same time against the same environment, state corruption is a real risk. For a distributed honeynet with nodes in multiple regions and eventually multiple cloud providers, a robust state strategy is non-negotiable.
+
+## What this adds
+
+A standalone `terraform/backend/` module that provisions:
+
+- **S3 bucket** with versioning, AES-256 server-side encryption, and public access fully blocked — state files contain sensitive output values (IPs, ARNs) and must never be publicly accessible
+- **S3 lifecycle rule** that expires noncurrent state versions after 90 days, keeping storage costs near zero
+- **DynamoDB table** (`PAY_PER_REQUEST`) for state locking — this ensures only one `terraform apply` runs at a time across all contributors and CI jobs
+- **Point-in-time recovery** on the DynamoDB table for extra durability
+
+## How to use
+
+```bash
+cd terraform/backend
+terraform init        # uses local state just for this bootstrap
+terraform apply
+```
+
+The `backend_config_snippet` output will print the exact `backend "s3" {}` block to paste into any other module.
+
+## Design decisions
+
+- Kept as a completely separate module so it can be applied with local state first — bootstrapping a remote backend with itself is a chicken-and-egg problem
+- `force_destroy = false` on the S3 bucket intentionally prevents accidental state deletion via Terraform
+- No KMS CMK for now — AES-256 managed key is sufficient and avoids additional IAM complexity at this stage
+
+## Relation to existing PRs
+
+This module is fully isolated — it touches no files from PR #3, #5, or #7. Other modules can adopt the backend config at their own pace.
+
+Addresses the state management concern raised by @Aditya in #honeynet Slack.

--- a/terraform/backend/main.tf
+++ b/terraform/backend/main.tf
@@ -1,0 +1,110 @@
+# =============================================================================
+# Honeynet — Remote State Bootstrap
+#
+# This configuration provisions the S3 bucket and DynamoDB table required
+# to store and lock Terraform state remotely. It must be applied ONCE using
+# local state before all other modules switch to the remote backend.
+#
+# Usage:
+#   cd terraform/backend
+#   terraform init
+#   terraform apply
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# ------------------------------------------------------------------------------
+# S3 Bucket — Terraform State Storage
+# ------------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket        = var.state_bucket_name
+  force_destroy = false
+
+  tags = {
+    Project     = "honeynet"
+    ManagedBy   = "terraform"
+    Purpose     = "remote-state"
+    Environment = "global"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    id     = "expire-old-state-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# DynamoDB Table — State Locking
+# ------------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "tf_state_lock" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    Project     = "honeynet"
+    ManagedBy   = "terraform"
+    Purpose     = "state-locking"
+    Environment = "global"
+  }
+}

--- a/terraform/backend/outputs.tf
+++ b/terraform/backend/outputs.tf
@@ -1,0 +1,34 @@
+output "state_bucket_name" {
+  description = "Name of the S3 bucket storing Terraform state."
+  value       = aws_s3_bucket.tf_state.bucket
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the Terraform state S3 bucket."
+  value       = aws_s3_bucket.tf_state.arn
+}
+
+output "lock_table_name" {
+  description = "Name of the DynamoDB table used for state locking."
+  value       = aws_dynamodb_table.tf_state_lock.name
+}
+
+output "lock_table_arn" {
+  description = "ARN of the DynamoDB state lock table."
+  value       = aws_dynamodb_table.tf_state_lock.arn
+}
+
+output "backend_config_snippet" {
+  description = "Drop this block into any Terraform module's backend configuration."
+  value       = <<-EOT
+    terraform {
+      backend "s3" {
+        bucket         = "${aws_s3_bucket.tf_state.bucket}"
+        key            = "<module-name>/terraform.tfstate"
+        region         = "${var.aws_region}"
+        dynamodb_table = "${aws_dynamodb_table.tf_state_lock.name}"
+        encrypt        = true
+      }
+    }
+  EOT
+}

--- a/terraform/backend/variables.tf
+++ b/terraform/backend/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region where the state bucket and lock table will be created."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "state_bucket_name" {
+  description = "Globally unique S3 bucket name for Terraform remote state."
+  type        = string
+  default     = "honeynet-tfstate-global"
+}
+
+variable "lock_table_name" {
+  description = "DynamoDB table name for Terraform state locking."
+  type        = string
+  default     = "honeynet-tfstate-lock"
+}


### PR DESCRIPTION
## Summary
Sets up the shared remote state infrastructure for the project. Currently all modules use local state, which means state files sit on developer laptops and concurrent applies can silently corrupt each other. This PR fixes that permanently.

## Problem
Local Terraform state is fine for a solo experiment, but the moment two contributors run `terraform apply` at the same time against the same environment, state corruption is a real risk. For a distributed honeynet with nodes in multiple regions and eventually multiple cloud providers, a robust state strategy is non-negotiable.

## What this adds
A standalone `terraform/backend/` module that provisions:
- **S3 bucket** with versioning, AES-256 server-side encryption, and public access fully blocked — state files contain sensitive output values (IPs, ARNs) and must never be publicly accessible
- **S3 lifecycle rule** that expires noncurrent state versions after 90 days, keeping storage costs near zero
- **DynamoDB table** (`PAY_PER_REQUEST`) for state locking — this ensures only one `terraform apply` runs at a time across all contributors and CI jobs
- **Point-in-time recovery** on the DynamoDB table for extra durability
Resolves #10
## How to use
```bash
cd terraform/backend
terraform init        # uses local state just for this bootstrap
terraform apply