### PR TITLE
feat(terraform/gcp): add GCP honeypot module with VPC, firewall, and least-privilege SA

### DIFF
--- a/terraform/modules/gcp_honeypot/main.tf
+++ b/terraform/modules/gcp_honeypot/main.tf
@@ -1,0 +1,72 @@
+# Dedicated VPC for the Honeypot to isolate it from other project resources
+resource "google_compute_network" "honeypot_vpc" {
+  name                    = "${var.prefix}-vpc"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "honeypot_subnet" {
+  name          = "${var.prefix}-subnet"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = var.gcp_region
+  network       = google_compute_network.honeypot_vpc.id
+
+  log_config {
+    aggregation_interval = "INTERVAL_1_MIN"
+    flow_sampling        = 1.0
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}
+
+# Strict Firewall Rules: Allow ONLY specific bait ports (e.g., SSH, Telnet)
+resource "google_compute_firewall" "allow_bait_ports" {
+  name    = "${var.prefix}-allow-bait"
+  network = google_compute_network.honeypot_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = var.allowed_bait_ports
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["honeypot-node"]
+}
+
+# Dedicated least-privilege Service Account for the VM
+resource "google_service_account" "honeypot_sa" {
+  account_id   = "${var.prefix}-sa"
+  display_name = "Honeypot Node Service Account"
+}
+
+# The actual Honeypot Compute Instance
+resource "google_compute_instance" "honeypot_node" {
+  name         = "${var.prefix}-node"
+  machine_type = var.machine_type
+  zone         = "${var.gcp_region}-a"
+  tags         = ["honeypot-node"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.honeypot_vpc.name
+    subnetwork = google_compute_subnetwork.honeypot_subnet.name
+    access_config {
+      # Ephemeral public IP to expose the honeypot
+    }
+  }
+
+  # Shielded VM settings to prevent rootkit persistence
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  service_account {
+    email  = google_service_account.honeypot_sa.email
+    scopes = ["cloud-platform"]
+  }
+}

--- a/terraform/modules/gcp_honeypot/outputs.tf
+++ b/terraform/modules/gcp_honeypot/outputs.tf
@@ -1,0 +1,14 @@
+output "honeypot_public_ip" {
+  description = "The public IP address of the GCP honeypot instance."
+  value       = google_compute_instance.honeypot_node.network_interface[0].access_config[0].nat_ip
+}
+
+output "honeypot_vpc_name" {
+  description = "The name of the isolated VPC."
+  value       = google_compute_network.honeypot_vpc.name
+}
+
+output "service_account_email" {
+  description = "The email of the least-privilege service account attached to the VM."
+  value       = google_service_account.honeypot_sa.email
+}

--- a/terraform/modules/gcp_honeypot/variables.tf
+++ b/terraform/modules/gcp_honeypot/variables.tf
@@ -1,0 +1,23 @@
+variable "prefix" {
+  description = "Prefix for all resources created by this module."
+  type        = string
+  default     = "honeynet-gcp"
+}
+
+variable "gcp_region" {
+  description = "The GCP region to deploy the honeypot into."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "machine_type" {
+  description = "The GCP compute instance machine type."
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "allowed_bait_ports" {
+  description = "List of TCP ports to expose to the public internet for attackers to hit."
+  type        = list(string)
+  default     = ["22", "2222", "23", "80"]
+}


### PR DESCRIPTION
## Summary
Adds a fully functional Terraform module for provisioning an isolated honeypot node in Google Cloud Platform (GCP). This fulfills the project's requirement for multi-cloud deployment capabilities.

## What this adds
A new, reusable module at `terraform/modules/gcp_honeypot/` that provisions:
- **Dedicated VPC & Subnet:** Complete network isolation from any other GCP projects, with VPC Flow Logs enabled at 100% sampling for network telemetry.
- **Strict Ingress Firewall:** By default, only allows traffic from `0.0.0.0/0` on designated bait ports (22, 2222, 23, 80). 
- **Compute Instance:** An `e2-micro` Ubuntu 22.04 VM with an ephemeral public IP to act as the target.
- **Shielded VM Configuration:** Secure Boot and vTPM are explicitly enabled to prevent rootkits from persisting below the OS level if the attacker achieves privilege escalation.
- **Least-Privilege Service Account:** The VM runs under a dedicated SA rather than the default compute SA, strictly limiting the blast radius if the instance metadata service is queried.

## Relation to existing code
This module is isolated within the `modules/` directory and does not conflict with existing AWS configurations. It uses variables so the orchestrator can easily spin up multiple nodes across different GCP regions.

Resolves #11