### PR TITLE
Initialized terraform file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# honeynet
-Develop a scalable, cloud-native honeypot deployment framework that leverages Terraform to provision and manage honeypot instances across multiple geographic regions. 
+# Cloud-Native Honeynet Platform
+
+A distributed, adaptive honeynet platform with centralized control, dynamic deception, and cloud-native deployment.
+
+## Quick Start
+
+### Prerequisites
+- Terraform >= 1.0
+- AWS CLI configured with credentials
+- SSH key pair
+
+### Initial Setup
+```bash
+cd infrastructure/terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+### Verification
+```bash
+# Get the public IP
+terraform output public_ip
+
+# SSH into the VM
+ssh -i ~/.ssh/your-key.pem ec2-user@$(terraform output public_ip)
+```
+
+## Architecture
+This is the foundational setup for a distributed honeynet system. Current implementation provisions a single VM as the building block for future multi-region deployments.
+
+## Next Steps
+- Honeypot installation and configuration
+- Multi-region deployment
+- Logging and monitoring setup
+- Automation and orchestration 

--- a/docs/terraform-setup.md
+++ b/docs/terraform-setup.md
@@ -1,0 +1,51 @@
+# Terraform Setup Guide
+
+## Prerequisites
+1. Install Terraform >= 1.0
+2. Configure AWS CLI with credentials
+3. Create SSH key pair in AWS
+
+## Setup Steps
+
+### 1. Initialize Terraform
+```bash
+cd infrastructure/terraform
+terraform init
+```
+
+### 2. Plan Deployment
+```bash
+terraform plan -var="key_name=your-key-name"
+```
+
+### 3. Apply Configuration
+```bash
+terraform apply -var="key_name=your-key-name" -auto-approve
+```
+
+### 4. Verify Deployment
+```bash
+# Get public IP
+terraform output public_ip
+
+# Test SSH connection
+ssh -i ~/.ssh/your-key.pem ec2-user@$(terraform output public_ip)
+```
+
+### 5. Cleanup (if needed)
+```bash
+terraform destroy -auto-approve
+```
+
+## Troubleshooting
+
+### Common Issues
+- **SSH Key Not Found**: Ensure key pair exists in AWS region
+- **Permission Denied**: Check SSH key permissions (chmod 400)
+- **Instance Not Accessible**: Verify security group allows SSH
+
+### Next Steps
+Once VM is accessible, proceed with:
+1. Honeypot installation
+2. Logging configuration
+3. Multi-region setup

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Call the VM module
+module "honeypot_vm" {
+  source = "./modules/vm"
+  
+  instance_type = var.instance_type
+  ami_id       = var.ami_id
+  key_name     = var.key_name
+  subnet_id    = var.subnet_id
+  
+  tags = {
+    Name        = "honeynet-platform-initial"
+    Project     = "honeynet-platform"
+    Environment = "development"
+    Purpose     = "initial-setup"
+  }
+}

--- a/infrastructure/terraform/modules/vm/main.tf
+++ b/infrastructure/terraform/modules/vm/main.tf
@@ -1,0 +1,58 @@
+# Get default VPC
+data "aws_vpc" "default" {
+  default = true
+}
+
+# Get default subnets
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# Use provided subnet or default to first available subnet
+locals {
+  subnet_id = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.default.ids[0]
+}
+
+# Security group for SSH access
+resource "aws_security_group" "honeypot_sg" {
+  name        = "honeypot-ssh-sg"
+  description = "Security group for honeypot VM with SSH access"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "honeypot-ssh-sg"
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "honeypot" {
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  subnet_id                   = local.subnet_id
+  vpc_security_group_ids      = [aws_security_group.honeypot_sg.id]
+  associate_public_ip_address = true
+
+  tags = merge(var.tags, {
+    Name = "honeynet-platform-vm"
+  })
+}

--- a/infrastructure/terraform/modules/vm/outputs.tf
+++ b/infrastructure/terraform/modules/vm/outputs.tf
@@ -1,0 +1,19 @@
+output "public_ip" {
+  description = "Public IP address of the VM"
+  value       = aws_instance.honeypot.public_ip
+}
+
+output "instance_id" {
+  description = "Instance ID of the created VM"
+  value       = aws_instance.honeypot.id
+}
+
+output "private_ip" {
+  description = "Private IP address of the VM"
+  value       = aws_instance.honeypot.private_ip
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.honeypot_sg.id
+}

--- a/infrastructure/terraform/modules/vm/variables.tf
+++ b/infrastructure/terraform/modules/vm/variables.tf
@@ -1,0 +1,31 @@
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for the VM"
+  type        = string
+}
+
+variable "key_name" {
+  description = "SSH key pair name"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for VM deployment"
+  type        = string
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR blocks allowed for SSH access"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "public_ip" {
+  description = "Public IP address of the honeypot VM"
+  value       = module.honeypot_vm.public_ip
+}
+
+output "instance_id" {
+  description = "Instance ID of the created VM"
+  value       = module.honeypot_vm.instance_id
+}
+
+output "ssh_connection_command" {
+  description = "Command to connect via SSH"
+  value       = "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${module.honeypot_vm.public_ip}"
+}

--- a/infrastructure/terraform/provider.tf
+++ b/infrastructure/terraform/provider.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+  
+  default_tags {
+    tags = {
+      Project     = "honeynet-platform"
+      ManagedBy   = "terraform"
+      Environment = "development"
+    }
+  }
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "AWS region for deployment"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ami_id" {
+  description = "AMI ID for the VM"
+  type        = string
+  default     = "ami-0c02fb55956c7d316" # Amazon Linux 2
+}
+
+variable "key_name" {
+  description = "SSH key pair name"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for VM deployment"
+  type        = string
+  default     = ""
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR blocks allowed for SSH access"
+  type        = string
+  default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
**Summary:**

The basic foundational Terraform infrastructure for the Honeynet Platform by implementing a minimal setup that provisions single VM with SSH access. This serves as building block for future multi-region distributed deployments.

**Changes Made**

- Created Terraform project structure with module organization

**Changes to be made**

- Implement single VM provisioning with security group and SSH access
- Add output configuration for public IP retrieval
- Included provider configuration and backend setup

**Verification Steps to be performed**

- [ ] `terraform init` completes successfully
- [ ] `terraform apply` creates a single VM
- Public IP is returned as output
- SSH access to VM works with provided key

This PR is for concerning issue #16 