### PR TITLE
Add initial project structure setup

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,30 @@
+name: terraform validate
+
+on:
+  pull_request:
+    paths:
+      - "terraform/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.5.0
+
+      - name: format check
+        run: terraform fmt -check -recursive
+        working-directory: terraform
+
+      - name: init
+        run: terraform init -backend=false
+        working-directory: terraform
+
+      - name: validate
+        run: terraform validate
+        working-directory: terraform

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,6 +1,7 @@
 name: terraform validate
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "terraform/**"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# terraform
 .terraform/
 *.tfstate
 *.tfstate.backup
@@ -6,10 +5,6 @@
 .terraform.lock.hcl
 terraform.tfvars
 backend.tfvars
-
-# keys
 *.pem
 *.key
-
-# misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.plan
+.terraform.lock.hcl
+terraform.tfvars
+backend.tfvars
+
+# keys
+*.pem
+*.key
+
+# misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # honeynet
-Develop a scalable, cloud-native honeypot deployment framework that leverages Terraform to provision and manage honeypot instances across multiple geographic regions. 
+
+Terraform-based framework for deploying honeypots across multiple cloud regions.
+
+One config file, one command — honeypot nodes running in NA, EU, and APAC,
+with a central Prometheus/Grafana stack collecting logs from all of them.
+
+Built for GSoC 2026 under C2SI. Architecture follows the same pattern as
+GeoDNSScanner but adapted for honeypot infrastructure on AWS.
+
+## what it does
+
+- provisions EC2 instances per region via Terraform
+- each node runs Cowrie or Dionaea inside Docker
+- central monitoring node collects metrics via Prometheus, visualized in Grafana
+- scripts handle the full lifecycle: deploy, health check, teardown
+
+## usage
+```bash
+cp terraform/terraform.tfvars.example terraform/terraform.tfvars
+# fill in your regions, key path, etc.
+
+./scripts/deploy.sh
+./scripts/health_check.sh
+./scripts/teardown.sh
+```
+
+## requirements
+
+- Terraform >= 1.5.0
+- AWS account + credentials configured via `aws configure`
+- SSH key pair
+
+## project structure
+```
+terraform/
+  modules/
+    honeypot-node/    ec2 instance + docker bootstrap per region
+    monitoring/       prometheus + grafana central stack
+    networking/       vpc and subnet config
+  main.tf
+  variables.tf
+  outputs.tf
+  terraform.tfvars.example
+scripts/
+  deploy.sh
+  teardown.sh
+  health_check.sh
+docker/
+  cowrie/
+  dionaea/
+.github/
+  workflows/
+    terraform-validate.yml
+```
+
+## status
+
+Core structure in place. Multi-region wiring, monitoring stack,
+and CI pipeline are the next milestones.

--- a/docker/cowrie/cowrie.cfg
+++ b/docker/cowrie/cowrie.cfg
@@ -1,0 +1,4 @@
+[honeypot]
+hostname = svr04
+log_path = var/log/cowrie
+download_path = var/lib/cowrie/downloads

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../terraform"
+
+echo "initializing..."
+terraform init -backend-config=backend.tfvars
+
+echo "planning..."
+terraform plan -var-file=terraform.tfvars -out=honeynet.plan
+
+echo "applying..."
+terraform apply honeynet.plan
+
+echo ""
+echo "done. node IPs:"
+terraform output honeypot_ips
+
+echo ""
+echo "grafana:"
+terraform output grafana_url

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../terraform"
+
+IPS=$(terraform output -json honeypot_ips | jq -r '.[]')
+
+if [ -z "$IPS" ]; then
+  echo "no honeypot nodes found. has the infrastructure been deployed?"
+  exit 1
+fi
+
+for ip in $IPS; do
+  echo -n "checking $ip... "
+  result=$(ssh -o StrictHostKeyChecking=no \
+               -o ConnectTimeout=5 \
+               ubuntu@"$ip" \
+               "docker ps --format '{{.Names}}'" 2>/dev/null)
+
+  if echo "$result" | grep -qE "cowrie|dionaea"; then
+    echo "ok ($(echo "$result" | grep -E 'cowrie|dionaea'))"
+  else
+    echo "FAIL — no honeypot container running"
+  fi
+done

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../terraform"
+
+echo "this will destroy all honeynet infrastructure."
+read -p "are you sure? (yes/no): " confirm
+
+if [ "$confirm" != "yes" ]; then
+  echo "aborted."
+  exit 0
+fi
+
+terraform destroy -var-file=terraform.tfvars -auto-approve
+echo "all nodes destroyed."

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    # configure via backend.tfvars
+    # bucket = "your-state-bucket"
+    # key    = "honeynet/terraform.tfstate"
+    # region = "us-east-1"
+  }
+}
+
+module "honeypot_node" {
+  for_each = toset(var.regions)
+
+  source        = "./modules/honeypot-node"
+  region        = each.key
+  honeypot_type = var.honeypot_type
+  instance_type = var.instance_type
+  ssh_public_key_path = var.ssh_public_key_path
+}
+
+module "monitoring" {
+  source       = "./modules/monitoring"
+  honeypot_ips = [for node in module.honeypot_node : node.public_ip]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,10 +19,10 @@ terraform {
 module "honeypot_node" {
   for_each = toset(var.regions)
 
-  source        = "./modules/honeypot-node"
-  region        = each.key
-  honeypot_type = var.honeypot_type
-  instance_type = var.instance_type
+  source              = "./modules/honeypot-node"
+  region              = each.key
+  honeypot_type       = var.honeypot_type
+  instance_type       = var.instance_type
   ssh_public_key_path = var.ssh_public_key_path
 }
 

--- a/terraform/modules/honeypot-node/main.tf
+++ b/terraform/modules/honeypot-node/main.tf
@@ -1,6 +1,3 @@
-provider "aws" {
-  region = var.region
-}
 
 data "aws_ami" "ubuntu" {
   most_recent = true

--- a/terraform/modules/honeypot-node/main.tf
+++ b/terraform/modules/honeypot-node/main.tf
@@ -1,0 +1,62 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "honeynet-key-${var.region}"
+  public_key = file(var.ssh_public_key_path)
+}
+
+resource "aws_security_group" "this" {
+  name        = "honeynet-sg-${var.region}"
+  description = "Honeypot traffic rules"
+
+  # port 22 is the honeypot — intentionally open
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # real management access on a non-standard port
+  ingress {
+    from_port   = 2222
+    to_port     = 2222
+    protocol    = "tcp"
+    cidr_blocks = var.management_cidr
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "honeypot" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  key_name               = aws_key_pair.this.key_name
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  user_data = templatefile("${path.module}/user_data.sh", {
+    honeypot_type = var.honeypot_type
+  })
+
+  tags = {
+    Name    = "honeynet-${var.region}"
+    Project = "honeynet"
+  }
+}

--- a/terraform/modules/honeypot-node/outputs.tf
+++ b/terraform/modules/honeypot-node/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip" {
+  value = aws_instance.honeypot.public_ip
+}

--- a/terraform/modules/honeypot-node/user_data.sh
+++ b/terraform/modules/honeypot-node/user_data.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+apt-get update -y
+apt-get install -y docker.io
+systemctl enable docker
+systemctl start docker
+
+if [ "${honeypot_type}" = "cowrie" ]; then
+  docker run -d \
+    --name cowrie \
+    --restart always \
+    -p 22:2222 \
+    -v /honeynet/logs:/cowrie/var/log/cowrie \
+    cowrie/cowrie:latest
+
+elif [ "${honeypot_type}" = "dionaea" ]; then
+  docker run -d \
+    --name dionaea \
+    --restart always \
+    --net=host \
+    -v /honeynet/logs:/opt/dionaea/var/log \
+    dinotools/dionaea:latest
+fi

--- a/terraform/modules/honeypot-node/variables.tf
+++ b/terraform/modules/honeypot-node/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  type = string
+}
+
+variable "honeypot_type" {
+  type    = string
+  default = "cowrie"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "ssh_public_key_path" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "management_cidr" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,6 +1,3 @@
-provider "aws" {
-  region = "us-east-1"
-}
 
 data "aws_ami" "ubuntu" {
   most_recent = true

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_instance" "monitoring" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.small"
+
+  user_data = templatefile("${path.module}/user_data.sh", {
+    honeypot_ips = join(",", var.honeypot_ips)
+  })
+
+  tags = {
+    Name    = "honeynet-monitoring"
+    Project = "honeynet"
+  }
+}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,3 @@
+output "grafana_url" {
+  value = "http://${aws_instance.monitoring.public_ip}:3000"
+}

--- a/terraform/modules/monitoring/user_data.sh
+++ b/terraform/modules/monitoring/user_data.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+apt-get update -y
+apt-get install -y docker.io docker-compose
+systemctl enable docker
+systemctl start docker
+
+mkdir -p /honeynet/monitoring
+cat > /honeynet/monitoring/docker-compose.yml << COMPOSE
+version: "3"
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    restart: always
+COMPOSE
+
+# write prometheus scrape config from the honeypot IPs passed in
+cat > /honeynet/monitoring/prometheus.yml << PROM
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: honeypots
+    static_configs:
+      - targets: [$(echo ${honeypot_ips} | tr ',' '\n' | sed "s/^/'/;s/$/:9100'/" | tr '\n' ',')]
+PROM
+
+cd /honeynet/monitoring && docker-compose up -d

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,8 @@
+variable "honeypot_ips" {
+  description = "IPs of honeypot nodes for Prometheus to scrape"
+  type        = list(string)
+}
+EOF\cat > terraform/modules/monitoring/outputs.tf << 'EOF'
+output "grafana_url" {
+  value = "http://${aws_instance.monitoring.public_ip}:3000"
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -2,7 +2,3 @@ variable "honeypot_ips" {
   description = "IPs of honeypot nodes for Prometheus to scrape"
   type        = list(string)
 }
-EOF\cat > terraform/modules/monitoring/outputs.tf << 'EOF'
-output "grafana_url" {
-  value = "http://${aws_instance.monitoring.public_ip}:3000"
-}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,4 @@
+# VPC and subnet config per region
+# expanding this during the GSoC coding period
+
+variable "region" { type = string }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "honeypot_ips" {
+  description = "Public IPs of deployed honeypot nodes by region"
+  value       = { for region, node in module.honeypot_node : region => node.public_ip }
+}
+
+output "grafana_url" {
+  description = "Grafana dashboard URL"
+  value       = module.monitoring.grafana_url
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+regions             = ["us-east-1", "eu-west-1", "ap-southeast-1"]
+honeypot_type       = "cowrie"
+instance_type       = "t3.micro"
+ssh_public_key_path = "~/.ssh/id_rsa.pub"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "regions" {
+  description = "AWS regions to deploy honeypot nodes into"
+  type        = list(string)
+  default     = ["us-east-1", "eu-west-1", "ap-southeast-1"]
+}
+
+variable "honeypot_type" {
+  description = "Which honeypot to run: cowrie or dionaea"
+  type        = string
+  default     = "cowrie"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for honeypot nodes"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to your SSH public key"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
I noticed the repo only had a LICENSE and README so I put together a starting point for the project structure while waiting for mentor feedback on direction.
Adds the terraform module layout (honeypot-node, monitoring, networking), bootstrap scripts for Cowrie and Dionaea via Docker, lifecycle scripts for deploy/teardown/healthcheck, and a basic GitHub Actions workflow that runs terraform validate on PRs.
One thing I wasn't sure about is that GeoDNSScanner targets GCP but I went with AWS here since that's what the project description mentions. If the preference is GCP-first or provider-agnostic from day one, happy to rework the provider config.
Not claiming this is the final architecture, just wanted something concrete to discuss.